### PR TITLE
Add gitignore file for windows and mac files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+thumbs.db


### PR DESCRIPTION
This adds a gitignore file so it won't track mac ds_store and windows thumbs.db files.