### PR TITLE
Add job search functionality

### DIFF
--- a/assets/javascript/jobsearch.js
+++ b/assets/javascript/jobsearch.js
@@ -1,0 +1,56 @@
+// TODO:
+// press enter to search, maybe clear out text
+// add jquery, add javascript references
+// verify images can be used
+// get data attribution for all datasets for readme
+// add IDs for job-api-dump
+
+$(document).ready(function(){
+
+// when button is clicked, send AJAX query to jobs API
+$(document.body).on("click", "#submit", function() {
+
+  var baseURL = "https://jobs.github.com/positions.json?";
+  var descriptionInput = $("#search-text").val().trim();
+  var location = "san+francisco";
+
+  // replace spaces in word with + to create a complete URL
+  var description = descriptionInput.split(" ").join("+");
+
+  // construct query URL
+  var queryURL = baseURL + "description=" + description + "&" + "location=" + location;
+
+  console.log(queryURL);
+
+// CORS requires a JSONP dataType
+
+  $.ajax({
+    url: queryURL,
+    method: 'GET',
+    dataType: 'jsonp'
+  }).then(function(response) {
+  console.log(response);
+
+  //console.log("Title " + response["0"].title);
+  //console.log("Company " + response["0"].company);
+  //console.log("Description " + response["0"].description.substring(0, 100));
+  //console.log("GitHub Jobs URL " + response["0"].url)
+
+  for (var i = 0; i < 5; i++) {
+    // console.log("Title " + response[i].title);
+    //console.log("Company " + response[i].company);
+    //$("#job" + i).text(response[i].title + " - " + response[i].company);
+    var jobUrl = response[i].url;
+    var jobTitle = response[i].title;
+    var jobCompany = response[i].company;
+    //var newLink = $("<a>");
+    //var jobAttr = $("#job" + i).attr("href", jobUrl);
+    var jobText = $("#job" + i).text(jobTitle + " - " + jobCompany);
+
+  }
+
+});
+
+});
+
+});

--- a/assets/javascript/jobsearch.js
+++ b/assets/javascript/jobsearch.js
@@ -1,7 +1,3 @@
-// TODO:
-// press enter to search, maybe clear out text
-// search only works one time
-
 $(document).ready(function(){
 
   // when button is clicked, send AJAX query to jobs API
@@ -17,31 +13,20 @@ $(document).ready(function(){
     // construct query URL
     var queryURL = baseURL + "description=" + description + "&" + "location=" + location;
 
-    console.log(queryURL);
-
-    // CORS requires a JSONP dataType
+    // API requires a JSONP dataType to avoid CORS issues
 
     $.ajax({
       url: queryURL,
       method: 'GET',
       dataType: 'jsonp'
     }).then(function(response) {
-      console.log(response);
 
-      //console.log("Title " + response["0"].title);
-      //console.log("Company " + response["0"].company);
-      //console.log("Description " + response["0"].description.substring(0, 100));
-      //console.log("GitHub Jobs URL " + response["0"].url)
-
+      // loop through the response, collect the URL, title, and company for the first five jobs returned
+      // create new list items on the page and make the text link to the source job application page
       for (var i = 0; i < 5; i++) {
-        console.log("hello");
-        // console.log("Title " + response[i].title);
-        //console.log("Company " + response[i].company);
-        //$("#job" + i).text(response[i].title + " - " + response[i].company);
         var jobUrl = response[i].url;
         var jobTitle = response[i].title;
         var jobCompany = response[i].company;
-        //<li id="job0" class="list-group-item">Cras justo odio</li>
         var $li = $("<li>");
         $li.attr("id", "job" + i);
         $li.addClass("list-group-item");
@@ -49,14 +34,9 @@ $(document).ready(function(){
         $a.text(jobTitle + " - " + jobCompany);
         $a.attr("href", jobUrl);
         $a.attr("target", "blank");
-        //console.log(a);
         $($li).append($a);
         $("#job-api-dump").append($li);
-
       }
-
     });
-
   });
-
 });

--- a/assets/javascript/jobsearch.js
+++ b/assets/javascript/jobsearch.js
@@ -1,56 +1,62 @@
 // TODO:
 // press enter to search, maybe clear out text
-// add jquery, add javascript references
-// verify images can be used
-// get data attribution for all datasets for readme
-// add IDs for job-api-dump
+// search only works one time
 
 $(document).ready(function(){
 
-// when button is clicked, send AJAX query to jobs API
-$(document.body).on("click", "#submit", function() {
+  // when button is clicked, send AJAX query to jobs API
+  $(document.body).on("click", "#submit", function() {
 
-  var baseURL = "https://jobs.github.com/positions.json?";
-  var descriptionInput = $("#search-text").val().trim();
-  var location = "san+francisco";
+    var baseURL = "https://jobs.github.com/positions.json?";
+    var descriptionInput = $("#search-text").val().trim();
+    var location = "san+francisco";
 
-  // replace spaces in word with + to create a complete URL
-  var description = descriptionInput.split(" ").join("+");
+    // replace spaces in word with + to create a complete URL
+    var description = descriptionInput.split(" ").join("+");
 
-  // construct query URL
-  var queryURL = baseURL + "description=" + description + "&" + "location=" + location;
+    // construct query URL
+    var queryURL = baseURL + "description=" + description + "&" + "location=" + location;
 
-  console.log(queryURL);
+    console.log(queryURL);
 
-// CORS requires a JSONP dataType
+    // CORS requires a JSONP dataType
 
-  $.ajax({
-    url: queryURL,
-    method: 'GET',
-    dataType: 'jsonp'
-  }).then(function(response) {
-  console.log(response);
+    $.ajax({
+      url: queryURL,
+      method: 'GET',
+      dataType: 'jsonp'
+    }).then(function(response) {
+      console.log(response);
 
-  //console.log("Title " + response["0"].title);
-  //console.log("Company " + response["0"].company);
-  //console.log("Description " + response["0"].description.substring(0, 100));
-  //console.log("GitHub Jobs URL " + response["0"].url)
+      //console.log("Title " + response["0"].title);
+      //console.log("Company " + response["0"].company);
+      //console.log("Description " + response["0"].description.substring(0, 100));
+      //console.log("GitHub Jobs URL " + response["0"].url)
 
-  for (var i = 0; i < 5; i++) {
-    // console.log("Title " + response[i].title);
-    //console.log("Company " + response[i].company);
-    //$("#job" + i).text(response[i].title + " - " + response[i].company);
-    var jobUrl = response[i].url;
-    var jobTitle = response[i].title;
-    var jobCompany = response[i].company;
-    //var newLink = $("<a>");
-    //var jobAttr = $("#job" + i).attr("href", jobUrl);
-    var jobText = $("#job" + i).text(jobTitle + " - " + jobCompany);
+      for (var i = 0; i < 5; i++) {
+        console.log("hello");
+        // console.log("Title " + response[i].title);
+        //console.log("Company " + response[i].company);
+        //$("#job" + i).text(response[i].title + " - " + response[i].company);
+        var jobUrl = response[i].url;
+        var jobTitle = response[i].title;
+        var jobCompany = response[i].company;
+        //<li id="job0" class="list-group-item">Cras justo odio</li>
+        var $li = $("<li>");
+        $li.attr("id", "job" + i);
+        $li.addClass("list-group-item");
+        var $a = $("<a>");
+        $a.text(jobTitle + " - " + jobCompany);
+        $a.attr("href", jobUrl);
+        $a.attr("target", "blank");
+        //console.log(a);
+        $($li).append($a);
+        $("#job-api-dump").append($li);
 
-  }
+      }
 
-});
+    });
 
-});
+  });
 
 });


### PR DESCRIPTION
This adds code to search the GitHub Jobs API.

- returns the first five results based on search string
- creates new list with the title, company, and link to the job details page
- uses a "-" to separate title from company (we can change this)

Required changes in  index.html:

- `<li>` items to be removed from "job-api-dump"
- jQuery link
- link to this js file

Currently, it looks like this:

![image](https://user-images.githubusercontent.com/4380498/35938971-9c25d532-0bff-11e8-9484-188a29b4d8de.png)

Note: needs to handle the case where no results are returned or the API is down/errors.