### PR TITLE
change monthly percents to 30, 40, 50

### DIFF
--- a/assets/javascript/salary.js
+++ b/assets/javascript/salary.js
@@ -47,12 +47,12 @@ $(document).ready(function(){
     return salaryMonthly;
   }
 
-  // calculate percents of monthly salary (25, 30, and 50)
+  // calculate percents of monthly salary (30, 40, and 50 percents)
   // pass to getHousingOptions function to find housing at these levels
   function calcAffordRanges(salary) {
     var percents = {
-      low : 0.25,
-      medium: 0.30,
+      low : 0.30,
+      medium: 0.40,
       high: 0.50
     }
     percents.low = Math.floor(percents.low * salary / 12);


### PR DESCRIPTION
This changes the monthly percents to 30, 40, and 50. Traditionally, 30 percent is the amount to spend on rent, but in more expensive places, it could be more like 40 or 50. Larger amounts could burden you, but could give you a better quality of life (and thus, back to the original purpose of the project, "Should I pay more to get a shorter commute and benefits of SF vs opportunity cost of time elsewhere?")

Tested via console logs of incoming salary data.