### PR TITLE
switch localestring to numeral.js library for currency formatting

### DIFF
--- a/assets/javascript/salary.js
+++ b/assets/javascript/salary.js
@@ -62,9 +62,9 @@ $(document).ready(function(){
     return housingOptions;
   }
 
-  // display the salary values as a string in currency (US Dollar) format for the HTML page
+  // display the salary values as a string in currency (US Dollar) format for the HTML page using Numeral.js library
   function displayAsDollars(salary) {
-    var salaryFormatted = salary.toLocaleString("en-US", { style: "currency", currency: "USD" });
+    var salaryFormatted = numeral(salary).format("$0,0");
     return salaryFormatted;
   }
 

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 	<script src="https://www.gstatic.com/firebasejs/4.9.1/firebase.js"></script>
 
-
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/numeral.js/2.0.6/numeral.min.js"></script>
 	<script type="text/javascript" src="assets/javascript/global.js"></script>
 	<script type="text/javascript" src="assets/javascript/loadHousingData.js"></script>
 


### PR DESCRIPTION
This adds a JS library http://numeraljs.com/ that does number and currency formatting. 

Adding this library meets the new technology assignment requirement, but it looks better anyway because the number displays as $142,729 instead of $142,729.00 as before.