### PR TITLE
swap title and company in UI text for job search results

### DIFF
--- a/assets/javascript/jobsearch.js
+++ b/assets/javascript/jobsearch.js
@@ -30,7 +30,7 @@ function getJobs(chosenJob) {
       $li.attr("id", "job" + i);
       $li.addClass("list-group-item");
       var $a = $("<a>");
-      $a.text(jobCompany + " - " + jobTitle + " - " + jobLocation);
+      $a.text(jobTitle + " - " + jobCompany + " - " + jobLocation);
       $a.attr("href", jobUrl);
       $a.attr("target", "blank");
       $($li).append($a);


### PR DESCRIPTION
per @zrowe's suggestion in Trello

Now looks like this:
![image](https://user-images.githubusercontent.com/4380498/36070095-fcb3384e-0ea8-11e8-98ec-40284418f11c.png)
 