### PR TITLE
Update readme text and add links to background image sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This project is licensed under the MIT License; see the [LICENSE.md](LICENSE.md)
 ## Acknowledgments and data credits
 
 - Job postings are from the [GitHub Jobs API](https://jobs.github.com/api).
-- Salary estimates provided by [Glassdoor](https://www.glassdoor.com/Salaries/index.htm) and based on salaries submitted anonymously to Glassdoor, as of February 2018.
+- Salary estimates are provided by [Glassdoor](https://www.glassdoor.com/Salaries/index.htm) and based on salaries submitted anonymously to Glassdoor, as of February 2018.
 - Rental housing data is from the [Quandl API](https://www.quandl.com/data/ZILLOW-Zillow-Real-Estate-Research) for Zillow Real Estate Research, as of February 2018.
 - San Francisco background images are from [orboloops9 on imgur](https://imgur.com/gallery/Kzyb3BE) and [Israeli American Council](https://www.israeliamerican.org/sites/default/files/homepage-sf-city-1080.jpg).
 - Thanks to Amber and Jerome for feedback and review.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WorthIT
 
-WorthIT can help you decide if you can work in a location and find affordable housing. First, you can search for available jobs and see the average salary for that position. Then, you can see the rental housing options, including number of bedrooms and locations, that you can get at various percentages of that salary. This can help you decide if it is worth it for you to accept a job offer and how much you will need to spend to find a rental that matches your needs.
+WorthIT can help you decide if you can work in a location and find affordable housing there. First, you can search for available jobs and see the average salary for that position. Then, you can see the rental housing options, including number of bedrooms and locations, that you can get at various percentages of that salary. This can help you decide if it is worth it for you to accept a job offer and how much you will need to spend to find a rental that matches your needs.
 
 ![animated gif showing start screen of app](animated-dropdown.gif)
 
@@ -11,7 +11,7 @@ The app is deployed on https://zrowe.github.io/WorthIt/.
 1. Choose a job title from the drop-down list.
 2. View job openings from the GitHub Jobs site that match the title. Click the link to view the original posting, get more details about it, and apply.
 3. View the average salary in San Francisco for that job title, as compiled by Glassdoor.
-4. View the types of rental housing options in San Francisco and neighboring cities that are within 25-, 35-, and 50-percent of that salary.
+4. View the types of rental housing options in San Francisco and neighboring cities that are within 30-, 40-, and 50-percent of that salary.
 5. Choose a different job title to see how the salary affects what you can get for the money.
 
 ### Installation
@@ -20,10 +20,10 @@ To run locally for development purposes, clone this repository and open `index.h
 
 ## Technology
 
-- [AJAX](https://en.wikipedia.org/wiki/Ajax_(programming)): to query job board API
-- [Bootstrap (version 4)](https://getbootstrap.com/docs/4.0/getting-started/introduction/): to build the user interface and make the website mobile-responsive
-- [Firebase](https://firebase.google.com/): to cache housing data for quicker access
-- JavaScript and [jQuery](https://jquery.com/): to code the app and interact with user interface elements
+- [AJAX](https://en.wikipedia.org/wiki/Ajax_(programming)) to query job board and housing APIs.
+- HTML, CSS, and [Bootstrap (version 4)](https://getbootstrap.com/docs/4.0/getting-started/introduction/) to build the user interface and make the website mobile-responsive.
+- [Firebase](https://firebase.google.com/) to cache housing data for quicker access.
+- JavaScript and [jQuery](https://jquery.com/) to code the app and interact with user interface elements.
 
 ## Contributors
 
@@ -39,7 +39,8 @@ This project is licensed under the MIT License; see the [LICENSE.md](LICENSE.md)
 
 ## Acknowledgments and data credits
 
-- Job postings are from the [GitHub Jobs API](https://jobs.github.com/api)
-- Estimates provided by [Glassdoor](https://www.glassdoor.com/Salaries/index.htm) and based on salaries submitted anonymously to Glassdoor as of February 2018.
-- Rental housing data is from the [Quandl API](https://www.quandl.com/data/ZILLOW-Zillow-Real-Estate-Research) for Zillow Real Estate Research.
-- Amber and Jerome for feedback and review
+- Job postings are from the [GitHub Jobs API](https://jobs.github.com/api).
+- Salary estimates provided by [Glassdoor](https://www.glassdoor.com/Salaries/index.htm) and based on salaries submitted anonymously to Glassdoor, as of February 2018.
+- Rental housing data is from the [Quandl API](https://www.quandl.com/data/ZILLOW-Zillow-Real-Estate-Research) for Zillow Real Estate Research, as of February 2018.
+- San Francisco background images are from [orboloops9 on imgur](https://imgur.com/gallery/Kzyb3BE) and [Israeli American Council](https://www.israeliamerican.org/sites/default/files/homepage-sf-city-1080.jpg).
+- Thanks to Amber and Jerome for feedback and review.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To run locally for development purposes, clone this repository and open `index.h
 
 ## License
 
-This project is licensed under the MIT License; see the [LICENSE.md](LICENSE.md) file for details.
+This project is licensed under the MIT License; see the [LICENSE](LICENSE) file for details.
 
 ## Acknowledgments and data credits
 


### PR DESCRIPTION
Minor updates to some of the text in the readme; add links to the background images.

Note: there are IDs with background images referenced in the CSS that do not seem to be used in index.html. This list includes only those that I believe are actually used.