### PR TITLE
Update readme, fix typos in index, fix improperly closed html tag, make intro table better

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,5 @@ This project is licensed under the MIT License; see the [LICENSE](LICENSE) file 
 - Job postings are from the [GitHub Jobs API](https://jobs.github.com/api).
 - Salary estimates are provided by [Glassdoor](https://www.glassdoor.com/Salaries/index.htm) and based on salaries submitted anonymously to Glassdoor, as of February 2018.
 - Rental housing data is from the [Quandl API](https://www.quandl.com/data/ZILLOW-Zillow-Real-Estate-Research) for Zillow Real Estate Research, as of February 2018.
-- San Francisco background images are from [orboloops9 on imgur](https://imgur.com/gallery/Kzyb3BE) and [Israeli American Council](https://www.israeliamerican.org/sites/default/files/homepage-sf-city-1080.jpg).
+- San Francisco background image is from [orboloops9 on imgur](https://imgur.com/gallery/Kzyb3BE).
 - Thanks to Amber and Jerome for feedback and review.

--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@
 		</table>
 
 
-			<p id="quandl">Data From Quandl Api</p>
+			<p id="quandl">Rental housing data is from the Quandl API for Zillow Real Estate Research.</p>
 
   		</div>
 	</div>

--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
 			  </thead>
 			  <tbody id="info-output">
 			    <tr>
-			      <td>San Francisico</td>
+			      <td>San Francisco</td>
 			      <td>1B</td>
 			      <td>2B</td>
 			      <td>3B</td>

--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@
 			      <th>Location</th>
 			      <th>30% of Salary</th>
 			      <th>40% of Salary</th>
-			      <th>50% of salary</th>
+			      <th>50% of Salary</th>
 			    </tr>
 
 			  </thead>

--- a/index.html
+++ b/index.html
@@ -120,23 +120,23 @@
 			  <tbody id="info-output">
 			    <tr>
 			      <td>San Francisco</td>
-			      <td>1B</td>
-			      <td>2B</td>
-			      <td>3B</td>
+			      <td>Studio</td>
+			      <td>1 Bedroom</td>
+			      <td>2 Bedroom</td>
 			    </tr>
 
 			    <tr>
 			      <td>Oakland</td>
-			      <td>2B</td>
-			      <td>1B</td>
-			      <td>3B</td>
+			      <td>1 Bedroom</td>
+			      <td>2 Bedroom</td>
+			      <td>3 Bedroom</td>
 			    </tr>
 
 			    <tr>
 			      <td>Hayward</td>
-			      <td>3B</td>
-			      <td>2B</td>
-			      <td>1B</td>
+			      <td>3 Bedroom</td>
+			      <td>3 Bedroom</td>
+			      <td>3 Bedroom</td>
 			    </tr>
 			</tbody>
 		</table>

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
 					</div>
 					<div class="col-md-3"></div>
 				</div>
-				
+
 			</div>
 		</div>
 
@@ -82,10 +82,10 @@
 					<div class="card-body">
 						<div class="card">
 							<div id="avg" class="card-body">
-								<h3 id="avg-sal-heading"></h2>
+								<h3 id="avg-sal-heading"></h3>
 								<h2 id="avg-sal-dump"></h2>
 
-								
+
 								<p id="avg-sal-credit"></p>
 
 							</div>


### PR DESCRIPTION
It looks like the background image behind the jobs and salary section has been deleted. This PR removes the reference to it in the readme acknowledgements.

This also includes updates to the index file:
- fix typo
- add proper Quandl attribution
- make salary heading consistent
- make h3 tag close properly
- make initial table have more realistic data and use same text (1 Bedroom vs 1B) that data now uses